### PR TITLE
added missing 4.0 to runtime grid and set max-parallel to 1 in order …

### DIFF
--- a/.github/workflows/runtime-publish.yml
+++ b/.github/workflows/runtime-publish.yml
@@ -69,9 +69,10 @@ jobs:
     needs: create-release
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
+        r: ["4.5", "4.4", "4.3", "4.2", "4.1", "4.0"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        r: ["4.5", "4.4", "4.3", "4.2", "4.1"]
 
     runs-on: ${{ matrix.os }}
     permissions:


### PR DESCRIPTION
…to handle timeouts correctly. Changed order of matrix to go os-by-os